### PR TITLE
docs: fix responses typo in prompts

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -645,7 +645,7 @@ keep it expanded by default
 ### [Dropped] ability to turn off reasoning and use gpt-5-nano
 i want to use gpt-5-nano, but i feel like the vercel-ai-sdk doesn't
 have a way to set reasoning to off, I think nano is still very slow
-because of that. look at the openai spec, with the repsonses api, and
+because of that. look at the openai spec, with the responses api, and
 see if there's a way i can turn off reasoning through vercel.
 ###
 


### PR DESCRIPTION
## Problem
`docs/prompts.md` refers to the OpenAI "repsonses api", which appears to be a typo for "responses api".

## Solution
Correct `repsonses` to `responses` in the prompt notes.

## Validation
- `git diff --check`
- `git grep -n -i 'repsonses' -- docs/prompts.md` returns no matches

## Confidence
80/100 (docs/typo). This is a one-word spelling correction in documentation/prompt notes.
