### PR TITLE
docs(context-lens): guide system prompt composition analysis

### DIFF
--- a/context-lens-spec.md
+++ b/context-lens-spec.md
@@ -143,6 +143,23 @@ context-lens
 
 The help text is also the intended system prompt / agent instructions for using the tool. It should show the single supported interface and canonical examples.
 
+### System-prompt composition recipe
+
+The help text should also describe the system-prompt composition use case. When
+an agent compares system prompts, it should use a shared `prompt_composition`
+dimension across all prompt files, with these initial components:
+
+- `workflow_guidance`: process, planning, task management, implementation, verification, and Git instructions.
+- `personality_steering`: tone, interaction style, initiative, progress updates, and final-answer instructions.
+- `tool_instructions`: tool descriptions, schemas, tool choice, and tool-use policy.
+- `code_style`: coding conventions, patterns, comments, formatting, and implementation preferences.
+- `environment_details`: runtime, filesystem, permissions, sandbox, platform, date, and project-context instructions.
+
+The agent should keep definitions and colors consistent across files, inspect the
+classified source segments before stating a finding, and distinguish prompt
+composition from behavioral evidence. Context Lens can reveal the former; a
+prompt swap or controlled evaluation is needed to establish the latter.
+
 ## CLI flags
 
 ### `--spec <path|->`

--- a/context-lens/README.md
+++ b/context-lens/README.md
@@ -4,6 +4,22 @@ Agent-facing CLI for analyzing AI conversation transcripts.
 
 Choose dimensions that answer the user's question. Do not default to generic code-area axes unless the user specifically asks for that breakdown.
 
+## System-prompt composition
+
+When a user asks to compare system prompts, use a shared `prompt_composition`
+dimension across every prompt. A useful starting taxonomy is:
+
+- `workflow_guidance` — planning, task management, implementation, verification, and Git instructions.
+- `personality_steering` — tone, interaction style, initiative, progress updates, and final-answer instructions.
+- `tool_instructions` — tool descriptions, schemas, tool choice, and tool-use policy.
+- `code_style` — coding conventions, patterns, comments, formatting, and implementation preferences.
+- `environment_details` — runtime, filesystem, permissions, sandbox, platform, date, and project-context instructions.
+
+Use identical component definitions and colors across the comparison. Inspect the
+underlying segments before writing a finding. The output measures classified
+prompt composition; it does not by itself prove that an instruction changes
+model behavior.
+
 ```bash
 context-lens --spec - session.jsonl <<'JSON'
 {

--- a/context-lens/src/cli.ts
+++ b/context-lens/src/cli.ts
@@ -34,6 +34,25 @@ information_type; for process analysis, activity_type; for source mix,
 context_source. context-lens appends the low-level JSON output requirements for
 segmentation.
 
+System-prompt composition:
+When comparing system prompts, use one shared prompt_composition dimension
+across all files. Start with these components unless the user's question calls
+for a different taxonomy:
+  - workflow_guidance: process, planning, task management, implementation,
+    verification, and Git instructions.
+  - personality_steering: tone, interaction style, initiative, progress
+    updates, and final-answer instructions.
+  - tool_instructions: tool descriptions, schemas, tool choice, and tool-use
+    policy.
+  - code_style: coding conventions, patterns, comments, formatting, and
+    implementation preferences.
+  - environment_details: runtime, filesystem, permissions, sandbox, platform,
+    date, and project-context instructions.
+Use the same component definitions and colors for every prompt in a comparison.
+Inspect the source segments before making claims: classifications are useful
+annotations, not ground truth. Context Lens can show composition differences;
+test prompt-behavior claims separately.
+
 Canonical invocation; replace the dimension/components with ones chosen for the
 user's investigation:
   context-lens --spec - session.jsonl <<'JSON'


### PR DESCRIPTION
## Summary
- add a system-prompt composition recipe to Context Lens agent instructions (`--help`)
- document a consistent five-category taxonomy for comparing prompt composition
- clarify that classified composition is not behavioral proof

## Validation
- `bun run check` (in `context-lens`)
- `npm test`