### PR TITLE
docs(context-lens): add general analysis workflow

### DIFF
--- a/context-lens-spec.md
+++ b/context-lens-spec.md
@@ -143,6 +143,20 @@ context-lens
 
 The help text is also the intended system prompt / agent instructions for using the tool. It should show the single supported interface and canonical examples.
 
+The help text should also give agents this general workflow:
+
+1. Start with the user's question and inspect the input files.
+2. Choose a small, explicit taxonomy that directly answers the question. Use
+   consistent component definitions and colors across files being compared.
+3. Write segmentation instructions that preserve the evidence needed for the
+   investigation while separating independent topics.
+4. Run the CLI, check errors and warnings, and inspect the classified source
+   segments before treating an aggregate as a finding.
+5. Refine segmentation or taxonomy when the first pass hides an important
+   distinction. Treat classifications as annotations, not ground truth.
+6. Improve export titles before publishing the export as a secret gist and
+   sharing its Context Viewer link.
+
 ## CLI flags
 
 ### `--spec <path|->`

--- a/context-lens/README.md
+++ b/context-lens/README.md
@@ -4,6 +4,23 @@ Agent-facing CLI for analyzing AI conversation transcripts.
 
 Choose dimensions that answer the user's question. Do not default to generic code-area axes unless the user specifically asks for that breakdown.
 
+## How to use it
+
+1. Start with a concrete question, such as what changed after compaction, how
+   two trajectories differ, or where a transcript spends its tokens.
+2. Inspect the input files before writing the analysis spec.
+3. Choose a small, explicit taxonomy that answers that question. Write clear
+   component descriptions and use the same taxonomy across compared files.
+4. Set segmentation instructions that keep related evidence together and split
+   independent topics.
+5. Run the CLI, check its errors and warnings, and use the analytics to find
+   patterns. Read the classified source segments before treating a pattern as a
+   finding.
+6. Refine the segmentation or taxonomy when the first pass is too broad, then
+   rerun. The classifications are useful annotations, not ground truth.
+7. To share the result, improve export titles, publish the export as a secret
+   gist, and provide the generated Context Viewer link.
+
 ```bash
 context-lens --spec - session.jsonl <<'JSON'
 {

--- a/context-lens/src/cli.ts
+++ b/context-lens/src/cli.ts
@@ -34,6 +34,23 @@ information_type; for process analysis, activity_type; for source mix,
 context_source. context-lens appends the low-level JSON output requirements for
 segmentation.
 
+General workflow:
+  1. Start with the user's question. Decide what a useful comparison or
+     breakdown would establish.
+  2. Inspect the input files before writing the spec. Learn their format,
+     scope, and the evidence they contain.
+  3. Define a small, explicit taxonomy. Each component description must say
+     what belongs in it; use the same taxonomy across files being compared.
+  4. Give segmentation instructions that preserve the evidence needed for the
+     question. Keep related text together and split independent topics.
+  5. Run context-lens, check errors and warnings, then use the analytics to
+     locate patterns. Inspect the classified source segments before making a
+     claim; classifications are annotations, not ground truth.
+  6. Refine the segmentation or taxonomy when it hides an important distinction
+     or combines unrelated material. Rerun and compare the result.
+  7. When sharing, improve the exported files' and groups' titles, publish the
+     export as a secret gist, and provide the resulting Context Viewer link.
+
 Canonical invocation; replace the dimension/components with ones chosen for the
 user's investigation:
   context-lens --spec - session.jsonl <<'JSON'


### PR DESCRIPTION
## Summary
- add a general question-to-evidence workflow to Context Lens agent instructions (`--help`)
- mirror the workflow in the README and CLI specification
- cover inspection, taxonomy design, refinement, and sharing without prescribing a specific analysis domain

## Validation
- `bun run check` (in `context-lens`)
- `npm test`